### PR TITLE
RFC:  Add a copy of the original HopLimit in the spare bits in the Packet Header Flags.

### DIFF
--- a/rfcs/2024-02-21-HopStart.md
+++ b/rfcs/2024-02-21-HopStart.md
@@ -2,90 +2,150 @@
 
 - Start Date: 2024-02-21
 - RFC PR: [Meshtastic/rfcs#0000](https://github.com/Meshtastic/rfcs/pull/0000)
-- Affected Components: Firmware, Packet contenets
+- Affected Components: Firmware, Packet contents
 
 ## Summary
 
-[One paragraph explanation of the feature or change and its impact across the Meshtastic ecosystem.]
+[One paragraph explanation of the feature or change and its impact across the
+Meshtastic ecosystem.]
 
-Place the original hop count in the unused bits of the Packet Header Flag. For the purpose of this document I will call this `HopStart`.
-This allows a reciever to deduce the number of hops the packet has made travaling from the sender, by subtracting HopLimit from HopStart.
+The originator of a packet places a copy of the original `HopLimit` in the
+unused bits of the Packet Header Flags. This new field will be called the
+`HopStart`.
+(see: https://meshtastic.org/docs/overview/mesh-algo/ for `PacketHeaderFlags`)
+This allows **all** receivers of the packet to deduce the number of hops the packet has made
+traveling from the originator. The hop count is deduced by subtracting `HopLimit` from `HopStart`.
+
+### Packet Header Flags 
+
+| Index |	# of Bits	| Usage        |
+|-------|-----------|--------------|
+|0      |3          |	`HopLimit`   |
+|3	    |1	        | `WantAck`    |
+|4	    |1	        | `ViaMQTT`    |
+|5 .. 7 |3	        | **HopStart** |
 
 ## Motivation
 
-[Why are we doing this? What problem does it solve or what use cases does it support? Discuss the benefits for the different components of the Meshtastic ecosystem, including end-users, developers, and core maintainers.]
+[Why are we doing this? What problem does it solve or what use cases does it
+support? Discuss the benefits for the different components of the Meshtastic
+ecosystem, including end-users, developers, and core maintainers.]
 
-Knowing the hop count provides a wealth of additional information that could be futher developed into features. Motivations include.
-* Knowing a packet is from a direct neibour
+Knowing the hop count every node on the mesh provides a wealth of additional information that could be
+further developed into features. Motivations include.
+* Knowing a packet is from a direct neighbors
 * Knowing how many hops away a node is.
-* Making better and targeted desisions about repeating a packet on the network.
-* Choosing a better 'HopLimit' to use to reply to a message. Use freindlier lower counts for local replies and increasing the count for more distant replies. 
+* Making better and targeted decisions about repeating a packet on the network.
+* Choosing a better `HopLimit` to use to reply to a message. Use friendlier
+  lower counts for local replies and increasing the count for more distant
+  replies.
+* Knowing a packet has been repeated and no longer incorrectly attributing the receive characteristics to the originator.
 
 ## Ecosystem Impact
 
-[Explain how this change will affect the various components of the Meshtastic ecosystem, including firmware, phone, desktop, and web applications. Address any coordination required among these components.]
+[Explain how this change will affect the various components of the Meshtastic
+ecosystem, including firmware, phone, desktop, and web applications. Address
+any coordination required among these components.]
 
-* The change itself is to existing packets and is designed to generate no extra traffic on the net, in itself.
-* More information about the topology of the network is know without any extra traffic.
-* Algerithums can use this feature to improve the performance of the network.
-* Unlocks further development where aplications could potentially display addition topolgy information about the mesh. Highlighting nearest neighbors or displaying the hop count to all known nodes.
-* Application can now destinguish between direct and indirect packets and therfore can attribute signal strength to only direct packets. This is not posible at the moment and a signal strength is incorrectly atributed to the sender, even if the recieed packet is from a node who repeated it.
+* The change itself is to existing packets and will generate no
+  extra traffic on the net.
+* More information about the topology of the network is know to every one
+  without any extra traffic.
+* Algorithms can use the hop count to improve the performance of the network.
+* Unlocks further development where applications could potentially display
+  addition topology information about the mesh. Highlighting nearest neighbors
+  or displaying the hop count to all known nodes.
+* Application can now distinguish between direct and indirect packets and
+  therefore can attribute signal strength to only direct packets. This is not
+  possible at the moment and a signal strength is incorrectly attributed to the
+  sender, even if the received packet is from a node who repeated it.
 
 ## Protocol Buffer Changes
 
-[Detail the changes proposed to Meshtastic's protocol buffer definitions, if any. Explain how these changes will be managed and propagated across the different applications and firmware.]
+[Detail the changes proposed to Meshtastic's protocol buffer definitions, if
+any. Explain how these changes will be managed and propagated across the
+different applications and firmware.]
 
-Addition of a HopStart field to packet's `Packet Header Flags`. This can be added to firmware. Derived features can be rolled out to applications once the firmware change is made.
+Addition of a `HopStart` field to packet's `Packet Header Flags`. This can be
+added to firmware. Derived features can be rolled out to applications once the
+firmware change is made.
 
 ## Technical Details
 
-[Provide a more in-depth technical explanation of the proposed changes, focusing on the high-level architecture and how different components of the ecosystem will interact with these changes. This section should explain your proposed solution in enough detail that someone familiar with the Meshtastic ecosystem can understand the design and implementation of the feature.]
+[Provide a more in-depth technical explanation of the proposed changes,
+focusing on the high-level architecture and how different components of the
+ecosystem will interact with these changes. This section should explain your
+proposed solution in enough detail that someone familiar with the Meshtastic
+ecosystem can understand the design and implementation of the feature.]
 
-Originator places the HopLimit in the HopLimit field, but also in the HopStart field. Repeaters preserve the packet contents apart from decromenting the HopLimit.
+Originator places the `HopLimit` in the `HopLimit` field, but also in the
+`HopStart` field. Repeaters preserve the packet contents apart from decrementing the
+`HopLimit`. It is highly likely that current firmware already does this.
 
 ### Compatibility Considerations
 
-[Discuss how the proposed changes will affect backward compatibility across the ecosystem. Include strategies for handling compatibility issues. Discuss whether this change requires any version bumps.]
+[Discuss how the proposed changes will affect backward compatibility across the
+ecosystem. Include strategies for handling compatibility issues. Discuss whether
+this change requires any version bumps.]
 
-Existing firmware will rpopulate this feild with zero. A reviever will see zero as either a legacy packet or a packet that has been sent with a zero HopLimit.
-The inability to destingwish between these two senarios is a limitation but often such packets have a special meaning and are therfor alraedy know to be zero hop packets.
-Repeaters should repeat the packet as is wheather they have this feature or are legacy.
+Existing firmware will populate this field with zero. A receiver will see zero
+as either a legacy packet or a packet that has been sent with a zero HopLimit.
+The inability to distinguish between these two scenarios is a limitation but
+often such packets have a special meaning and are therefor already know to be
+zero hop packets.
+Repeaters should repeat the packet as is whether they have this feature or are
+legacy.
 
 ### Security Considerations
 
-[Address any security implications of the proposed changes, especially those that might arise from modifications in protocol buffers and cross-component communication.]
+[Address any security implications of the proposed changes, especially those
+that might arise from modifications in protocol buffers and cross-component
+communication.]
 
 None that I can think of.
 
 ### Performance Considerations
 
-[Evaluate how the change will impact the performance of various components in the ecosystem, including the efficiency and responsiveness of Meshtastic devices and applications.]
+[Evaluate how the change will impact the performance of various components in
+the ecosystem, including the efficiency and responsiveness of Meshtastic devices
+and applications.]
 
-Zero impact on mesh performance or utalisation.
+**Zero** impact on mesh performance or utilization.
 
 ## Drawbacks
 
-[Discuss the potential downsides or limitations of the proposal. Why might this change be controversial or challenging to implement?]
+[Discuss the potential downsides or limitations of the proposal. Why might this
+change be controversial or challenging to implement?]
 
-No real drawbacks. Obtaining the benafits of this change requires further development.
+No real drawbacks. Obtaining the benefits of this change requires further
+development. This solution cannot distinguish between a legacy packet or one that
+was sent with a zero `HopLimit`
 
 ## Rationale and Alternatives
 
 - Zero impact.
-- Very useful addition information about all packets on the mesh
-- Trace route provides detail about intermediate nodes but requires extra mesh traffic and is very unreliable. It require the data to complete a round trip to be of any value.
+- Very useful addition information about all packets on the mesh available to
+  all receivers.
+- 'Trace route' provides detail about intermediate nodes but requires extra mesh
+  traffic and is very unreliable. It requires the data to complete a round trip
+  to be of any value. Trace route is not zero impact.
 
 ## Prior Art
 
-[Discuss any similar implementations in other projects or technologies and what can be learned from them. Include both successful and unsuccessful examples.]
+[Discuss any similar implementations in other projects or technologies and what
+can be learned from them. Include both successful and unsuccessful examples.]
 
 * Feature request: https://github.com/meshtastic/firmware/issues/3239
 * Partially implemented branch: https://github.com/GUVWAF/Meshtastic-device/tree/hopStart
   
 ## Unresolved Questions
 
-- Unsure the impact of adding the field to the Packet Header Flags, even if that field is unused.
-  Is the API robust enough for the recieving appication to work without modification, even when ignoring the addition field.
-  Would a legacy application work with firmware update with this feature?
-- Is it true the curent version of the hardware mean that the Packet Header Flags will be repeated on the network intactact even without an update?
-  It is not so bad if legacy repeaters repeated the header with this field zeroed, but it would be nice if thety did not do this.
+- Unsure the impact of adding the field to the `PacketHeaderFlags`, even if that
+  field is unused.
+  Is the API robust enough for current receiving application to work without
+  modification, even when ignoring the addition field.
+  Would a legacy application work with firmware updated with this feature?
+- Is it true the current version of the hardware repeats the 
+  `PacketHeaderFlags` on the network intact, even without an
+  update? It is not so bad if legacy repeaters repeated the header with this
+  field zeroed, but it would be nice if they did not do this.

--- a/rfcs/2024-02-21-HopStart.md
+++ b/rfcs/2024-02-21-HopStart.md
@@ -1,0 +1,91 @@
+# HopStart In Packet Header Flags
+
+- Start Date: 2024-02-21
+- RFC PR: [Meshtastic/rfcs#0000](https://github.com/Meshtastic/rfcs/pull/0000)
+- Affected Components: Firmware, Packet contenets
+
+## Summary
+
+[One paragraph explanation of the feature or change and its impact across the Meshtastic ecosystem.]
+
+Place the original hop count in the unused bits of the Packet Header Flag. For the purpose of this document I will call this `HopStart`.
+This allows a reciever to deduce the number of hops the packet has made travaling from the sender, by subtracting HopLimit from HopStart.
+
+## Motivation
+
+[Why are we doing this? What problem does it solve or what use cases does it support? Discuss the benefits for the different components of the Meshtastic ecosystem, including end-users, developers, and core maintainers.]
+
+Knowing the hop count provides a wealth of additional information that could be futher developed into features. Motivations include.
+* Knowing a packet is from a direct neibour
+* Knowing how many hops away a node is.
+* Making better and targeted desisions about repeating a packet on the network.
+* Choosing a better 'HopLimit' to use to reply to a message. Use freindlier lower counts for local replies and increasing the count for more distant replies. 
+
+## Ecosystem Impact
+
+[Explain how this change will affect the various components of the Meshtastic ecosystem, including firmware, phone, desktop, and web applications. Address any coordination required among these components.]
+
+* The change itself is to existing packets and is designed to generate no extra traffic on the net, in itself.
+* More information about the topology of the network is know without any extra traffic.
+* Algerithums can use this feature to improve the performance of the network.
+* Unlocks further development where aplications could potentially display addition topolgy information about the mesh. Highlighting nearest neighbors or displaying the hop count to all known nodes.
+* Application can now destinguish between direct and indirect packets and therfore can attribute signal strength to only direct packets. This is not posible at the moment and a signal strength is incorrectly atributed to the sender, even if the recieed packet is from a node who repeated it.
+
+## Protocol Buffer Changes
+
+[Detail the changes proposed to Meshtastic's protocol buffer definitions, if any. Explain how these changes will be managed and propagated across the different applications and firmware.]
+
+Addition of a HopStart field to packet's `Packet Header Flags`. This can be added to firmware. Derived features can be rolled out to applications once the firmware change is made.
+
+## Technical Details
+
+[Provide a more in-depth technical explanation of the proposed changes, focusing on the high-level architecture and how different components of the ecosystem will interact with these changes. This section should explain your proposed solution in enough detail that someone familiar with the Meshtastic ecosystem can understand the design and implementation of the feature.]
+
+Originator places the HopLimit in the HopLimit field, but also in the HopStart field. Repeaters preserve the packet contents apart from decromenting the HopLimit.
+
+### Compatibility Considerations
+
+[Discuss how the proposed changes will affect backward compatibility across the ecosystem. Include strategies for handling compatibility issues. Discuss whether this change requires any version bumps.]
+
+Existing firmware will rpopulate this feild with zero. A reviever will see zero as either a legacy packet or a packet that has been sent with a zero HopLimit.
+The inability to destingwish between these two senarios is a limitation but often such packets have a special meaning and are therfor alraedy know to be zero hop packets.
+Repeaters should repeat the packet as is wheather they have this feature or are legacy.
+
+### Security Considerations
+
+[Address any security implications of the proposed changes, especially those that might arise from modifications in protocol buffers and cross-component communication.]
+
+None that I can think of.
+
+### Performance Considerations
+
+[Evaluate how the change will impact the performance of various components in the ecosystem, including the efficiency and responsiveness of Meshtastic devices and applications.]
+
+Zero impact on mesh performance or utalisation.
+
+## Drawbacks
+
+[Discuss the potential downsides or limitations of the proposal. Why might this change be controversial or challenging to implement?]
+
+No real drawbacks. Obtaining the benafits of this change requires further development.
+
+## Rationale and Alternatives
+
+- Zero impact.
+- Very useful addition information about all packets on the mesh
+- Trace route provides detail about intermediate nodes but requires extra mesh traffic and is very unreliable. It require the data to complete a round trip to be of any value.
+
+## Prior Art
+
+[Discuss any similar implementations in other projects or technologies and what can be learned from them. Include both successful and unsuccessful examples.]
+
+* Feature request: https://github.com/meshtastic/firmware/issues/3239
+* Partially implemented branch: https://github.com/GUVWAF/Meshtastic-device/tree/hopStart
+  
+## Unresolved Questions
+
+- Unsure the impact of adding the field to the Packet Header Flags, even if that field is unused.
+  Is the API robust enough for the recieving appication to work without modification, even when ignoring the addition field.
+  Would a legacy application work with firmware update with this feature?
+- Is it true the curent version of the hardware mean that the Packet Header Flags will be repeated on the network intactact even without an update?
+  It is not so bad if legacy repeaters repeated the header with this field zeroed, but it would be nice if thety did not do this.


### PR DESCRIPTION
# Add HopStart to Packet Header Flags
[Add HopStart to Packet Header Flags](https://github.com/BillyBag2/rfcs/blob/HopStart/rfcs/2024-02-21-HopStart.md)

## Summary

The originator of a packet places a copy of the original `HopLimit` in the
unused bits of the Packet Header Flags. This new field will be called the
`HopStart`. (see: https://meshtastic.org/docs/overview/mesh-algo/ for `PacketHeaderFlags`)
This allows **all** receivers of the packet to deduce the number of hops the packet has made
traveling from the originator. The hop count is deduced by subtracting `HopLimit` from `HopStart`.

### Packet Header Flags 

| Index |	# of Bits	| Usage        |
|-------|-----------|--------------|
|0      |3          |	`HopLimit`   |
|3	    |1	        | `WantAck`    |
|4	    |1	        | `ViaMQTT`    |
|5 .. 7 |3	        | **HopStart** |
